### PR TITLE
First time use of cargo.io.

### DIFF
--- a/aoc14/Cargo.toml
+++ b/aoc14/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num = "0.4.1"


### PR DESCRIPTION
Using num::range_step_inclusive avoids the awkward dance around having to reverse a normal range iteration.